### PR TITLE
Fixed broken atomicity in pinMode due to added line for INPUT (to set it...

### DIFF
--- a/components/header.cpp
+++ b/components/header.cpp
@@ -67,7 +67,7 @@ static inline void pinModeSafe(uint8_t pin, uint8_t mode) {
 
     const bool write_is_atomic = DIGITALIO_NO_INTERRUPT_SAFETY
       || (__builtin_constant_p(mode)
-          && mode != INPUT_PULLUP
+          && mode == OUTPUT
           && _directionIsAtomic(pin));
     if(write_is_atomic) {
       pinModeFast(pin, mode);

--- a/digitalIOPerformance.h
+++ b/digitalIOPerformance.h
@@ -67,7 +67,7 @@ static inline void pinModeSafe(uint8_t pin, uint8_t mode) {
 
     const bool write_is_atomic = DIGITALIO_NO_INTERRUPT_SAFETY
       || (__builtin_constant_p(mode)
-          && mode != INPUT_PULLUP
+          && mode == OUTPUT
           && _directionIsAtomic(pin));
     if(write_is_atomic) {
       pinModeFast(pin, mode);


### PR DESCRIPTION
... not pulled-up).

I didn't realise that my last changes broke the atomicity in pinMode(..., INPUT);. This fixes it.
